### PR TITLE
pass types from function return value to eventually return value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ export = WixEventually;
 
 type UnPromisify<T> = T extends Promise<infer U> ? U : T;
 
-declare function WixEventually<ReturnValue extends any>(fn: (...args: any) => ReturnValue, opts?: WixEventually.Opts): Promise<UnPromisify<ReturnValue>>;
+declare function WixEventually<ReturnValue>(fn: (...args: any) => ReturnValue, opts?: WixEventually.Opts): Promise<UnPromisify<ReturnValue>>;
 
 declare namespace WixEventually {
   export interface Opts {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 export = WixEventually;
 
-declare function WixEventually(fn: Function, opts?: WixEventually.Opts): Promise<void>;
+type UnPromisify<T> = T extends Promise<infer U> ? U : T;
+
+declare function WixEventually<ReturnValue extends any>(fn: (...args: any) => ReturnValue, opts?: WixEventually.Opts): Promise<UnPromisify<ReturnValue>>;
 
 declare namespace WixEventually {
   export interface Opts {
@@ -8,6 +10,6 @@ declare namespace WixEventually {
     interval?: number;
   }
 
-  function _with(overrides: Opts): (fn: Function, opts?: WixEventually.Opts) => Promise<void>;
+  function _with(overrides: Opts): <ReturnValue extends any>(fn: (...args: any) => ReturnValue, opts?: WixEventually.Opts) => Promise<UnPromisify<ReturnValue>>;
   export { _with as with }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,6 @@ declare namespace WixEventually {
     interval?: number;
   }
 
-  function _with(overrides: Opts): <ReturnValue extends any>(fn: (...args: any) => ReturnValue, opts?: WixEventually.Opts) => Promise<UnPromisify<ReturnValue>>;
+  function _with(overrides: Opts): <ReturnValue>(fn: () => ReturnValue, opts?: WixEventually.Opts) => Promise<UnPromisify<ReturnValue>>;
   export { _with as with }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ export = WixEventually;
 
 type UnPromisify<T> = T extends Promise<infer U> ? U : T;
 
-declare function WixEventually<ReturnValue>(fn: (...args: any) => ReturnValue, opts?: WixEventually.Opts): Promise<UnPromisify<ReturnValue>>;
+declare function WixEventually<ReturnValue>(fn: () => ReturnValue, opts?: WixEventually.Opts): Promise<UnPromisify<ReturnValue>>;
 
 declare namespace WixEventually {
   export interface Opts {

--- a/test/typings.spec.ts
+++ b/test/typings.spec.ts
@@ -12,6 +12,29 @@ describe('wix-eventually types', function () {
         eventually(() => true).then(() => done());
     });
 
+    it('should return a promise resolving to function result', done => {
+        eventually(() => Promise.resolve('success')).then(result => {
+            expect(result).to.be.string('success');
+            done();
+        });
+    });
+
+    it('should return a promise resolving to function success result', done => {
+        let retryCount = 0;
+        const fn = () => {
+            retryCount++;
+            if (retryCount === 2) {
+                return 'success'
+            }
+            throw new Error('ups');
+        };
+
+        eventually(fn).then(result => {
+            expect(result).to.be.string('success');
+            done();
+        });
+    });
+
     it('does not require options', () => {
         return eventually(() => true);
     });
@@ -75,6 +98,29 @@ describe('wix-eventually types', function () {
 
             it('should return a promise', done => {
                 eventuallyWith(() => true).then(() => done());
+            });
+
+            it('should return a promise resolving to function result', done => {
+                eventuallyWith(() => Promise.resolve('message')).then(result => {
+                    expect(result).to.be.string('message');
+                    done();
+                });
+            });
+
+            it('should return a promise resolving to function success result', done => {
+                let retryCount = 0;
+                const fn = () => {
+                    retryCount++;
+                    if (retryCount === 2) {
+                        return 'success'
+                    }
+                    throw new Error('ups');
+                };
+
+                eventuallyWith(fn).then(result => {
+                    expect(result).to.be.string('success');
+                    done();
+                });
             });
 
             it('override with options with explicit call options', done => {


### PR DESCRIPTION
Actually right now `eventually` returns function return value, but it's not covered with types;